### PR TITLE
Accept uppercase extension .FBX

### DIFF
--- a/Assets/Packages/UnityFBXExporter/FBXExporter.cs
+++ b/Assets/Packages/UnityFBXExporter/FBXExporter.cs
@@ -41,12 +41,12 @@ namespace UnityFBXExporter
 		public static bool ExportGameObjToFBX(GameObject gameObj, string newPath, bool copyMaterials = false, bool copyTextures = false)
 		{
 			// Check to see if the extension is right
-			if(newPath.Remove(0, newPath.LastIndexOf('.')) != ".fbx")
+			if (Path.GetExtension(newPath).ToLower() != ".fbx")
 			{
 				Debug.LogError("The end of the path wasn't \".fbx\"");
 				return false;
 			}
-            
+
 			if(copyMaterials)
 				CopyComplexMaterialsToPath(gameObj, newPath, copyTextures);
 


### PR DESCRIPTION
The file extension is only accepted when it's lowercase .fbx 
The error message when writing an uppercase .FBX is not very clear:

![fbx](https://user-images.githubusercontent.com/3043173/30280121-411732ae-970f-11e7-921e-fa9bf7b0a757.png)

This pull request accepts someone writing an uppercase .FBX